### PR TITLE
Fix missing home route rendering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import { Routes, Route, Link } from "react-router-dom";
 import axios from "axios";
 
 function Home() {
@@ -41,12 +41,10 @@ function Products() {
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/products" element={<Products />} />
-      </Routes>
-    </Router>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/products" element={<Products />} />
+    </Routes>
   );
 }
 


### PR DESCRIPTION
## Summary
- remove the nested BrowserRouter wrapper inside App so routes render inside the provider from main

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c1d3a70083339331a782980c7fd4