### PR TITLE
Handle unexpected API payload shapes for listings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,8 +19,21 @@ function Products() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    axios.get(import.meta.env.VITE_API_URL + "/api/Product")
-      .then(res => setProducts(res.data))
+    axios
+      .get(import.meta.env.VITE_API_URL + "/api/Product")
+      .then(res => {
+        const payload = res?.data;
+        if (Array.isArray(payload)) {
+          setProducts(payload);
+        } else if (payload && Array.isArray(payload.data)) {
+          setProducts(payload.data);
+        } else if (payload && Array.isArray(payload.items)) {
+          setProducts(payload.items);
+        } else {
+          console.error("Formato inesperado de productos", payload);
+          setProducts([]);
+        }
+      })
       .catch(err => console.error("Error cargando productos", err))
       .finally(() => setLoading(false));
   }, []);

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -7,8 +7,21 @@ export default function Cart(){
   const navigate = useNavigate()
 
   useEffect(() => {
-    api.get('/cart')
-      .then(res => setItems(res.data))
+    api
+      .get('/cart')
+      .then(res => {
+        const payload = res?.data
+        if (Array.isArray(payload)) {
+          setItems(payload)
+        } else if (payload && Array.isArray(payload.data)) {
+          setItems(payload.data)
+        } else if (payload && Array.isArray(payload.items)) {
+          setItems(payload.items)
+        } else {
+          console.error('Formato inesperado del carrito', payload)
+          setItems([])
+        }
+      })
       .catch(err => {
         console.error(err)
         if (err.response && err.response.status === 401) navigate('/login')

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -6,8 +6,21 @@ export default function Products(){
   const [products, setProducts] = useState([])
 
   useEffect(() => {
-    api.get('/products')
-      .then(res => setProducts(res.data))
+    api
+      .get('/products')
+      .then(res => {
+        const payload = res?.data
+        if (Array.isArray(payload)) {
+          setProducts(payload)
+        } else if (payload && Array.isArray(payload.data)) {
+          setProducts(payload.data)
+        } else if (payload && Array.isArray(payload.items)) {
+          setProducts(payload.items)
+        } else {
+          console.error('Formato inesperado de productos', payload)
+          setProducts([])
+        }
+      })
       .catch(err => console.error(err))
   }, [])
 


### PR DESCRIPTION
## Summary
- guard against non-array payloads when loading products both on the home route and the dedicated products page
- apply the same normalization when loading cart items to avoid runtime errors from unexpected API responses
- log unexpected payload shapes so they can be diagnosed without breaking the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c5432fe88333945e94cfe0fe51c0