### PR TITLE
Fix product fetching and add auth CTA buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,50 +1,36 @@
-import { useEffect, useState } from "react";
-import { Routes, Route, Link } from "react-router-dom";
-import axios from "axios";
+import { Routes, Route, Outlet } from 'react-router-dom'
+import Navbar from './components/Navbar'
+import Home from './pages/Home'
+import Products from './pages/Products'
+import ProductDetail from './pages/ProductDetail'
+import Cart from './pages/Cart'
+import Checkout from './pages/Checkout'
+import Login from './pages/Login'
+import Register from './pages/Register'
 
-function Home() {
+function AppLayout(){
   return (
-    <div className="p-8 text-center">
-      <h1 className="text-3xl font-bold">Bienvenido al Ecommerce</h1>
-      <p className="mt-4">Explora productos, agrega al carrito y compra fácil 🚀</p>
-      <Link to="/products" className="mt-6 inline-block bg-blue-600 text-white px-4 py-2 rounded">
-        Ver productos
-      </Link>
+    <div className="min-h-screen bg-slate-100">
+      <Navbar />
+      <main className="container mx-auto px-4 py-8">
+        <Outlet />
+      </main>
     </div>
-  );
+  )
 }
 
-function Products() {
-  const [products, setProducts] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    axios.get(import.meta.env.VITE_API_URL + "/api/Product")
-      .then(res => setProducts(res.data))
-      .catch(err => console.error("Error cargando productos", err))
-      .finally(() => setLoading(false));
-  }, []);
-
-  if (loading) return <p className="p-4">Cargando productos...</p>;
-
-  return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-6">
-      {products.map(p => (
-        <div key={p.id} className="border rounded-lg p-4 shadow">
-          <h2 className="font-bold">{p.name}</h2>
-          <p className="text-gray-600">${p.price}</p>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-export default function App() {
+export default function App(){
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/products" element={<Products />} />
+      <Route element={<AppLayout />}>
+        <Route index element={<Home />} />
+        <Route path="/products" element={<Products />} />
+        <Route path="/products/:id" element={<ProductDetail />} />
+        <Route path="/cart" element={<Cart />} />
+        <Route path="/checkout" element={<Checkout />} />
+      </Route>
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
     </Routes>
-  );
+  )
 }
-

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,9 +1,19 @@
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://ecommercebackend-production-a5a1.up.railway.app/';
+const DEFAULT_API_URL = 'https://ecommercebackend-production-a5a1.up.railway.app/api';
+
+const rawBaseUrl = (import.meta.env.VITE_API_URL || DEFAULT_API_URL).trim();
+const baseURL = rawBaseUrl.replace(/\/+$/, '');
 
 const api = axios.create({
-  baseURL: API_URL,
+  baseURL,
+});
+
+api.interceptors.request.use(config => {
+  if (config.url?.startsWith('/')) {
+    config.url = config.url.slice(1);
+  }
+  return config;
 });
 
 api.interceptors.request.use(config => {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,9 +2,23 @@ import { Link } from 'react-router-dom'
 export default function Home(){
   return (
     <div>
-      <header className="bg-white rounded p-6 shadow mb-6">
+      <header className="mb-6 rounded bg-white p-6 shadow">
         <h1 className="text-3xl font-bold">Welcome to the store</h1>
         <p className="mt-2 text-gray-600">Shop the best deals</p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link
+            to="/login"
+            className="rounded bg-blue-600 px-5 py-2 text-white shadow hover:bg-blue-700"
+          >
+            Iniciar sesión
+          </Link>
+          <Link
+            to="/register"
+            className="rounded border border-blue-600 px-5 py-2 text-blue-600 hover:bg-blue-50"
+          >
+            Crear cuenta
+          </Link>
+        </div>
       </header>
 
       <section>

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -2,30 +2,63 @@ import { useEffect, useState } from 'react'
 import api from '../api/api'
 import { Link } from 'react-router-dom'
 
+const extractProducts = (payload) => {
+  if (Array.isArray(payload)) return payload
+  if (Array.isArray(payload?.products)) return payload.products
+  if (Array.isArray(payload?.data)) return payload.data
+  return null
+}
+
 export default function Products(){
   const [products, setProducts] = useState([])
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    api.get('/products')
-      .then(res => setProducts(res.data))
-      .catch(err => console.error(err))
+    const fetchProducts = async () => {
+      try {
+        const res = await api.get('/products')
+        const normalizedProducts = extractProducts(res.data)
+        if (!normalizedProducts) {
+          console.error('Formato inesperado de productos', res.data)
+          throw new Error('Formato inesperado de productos. Intenta nuevamente más tarde.')
+        }
+        setProducts(normalizedProducts)
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchProducts()
   }, [])
 
   return (
     <div>
       <h2 className="text-2xl font-semibold mb-4">Products</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {products.map(p => (
-          <div key={p.id} className="bg-white p-4 rounded shadow">
-            <h3 className="font-bold">{p.name}</h3>
-            <p className="text-sm text-gray-600">{p.description}</p>
-            <div className="mt-2 flex items-center justify-between">
-              <div className="text-lg font-semibold">${p.price}</div>
-              <Link to={`/products/${p.id}`} className="text-sm text-blue-600">View</Link>
+      {loading && <div>Cargando productos...</div>}
+      {error && (
+        <div className="mb-4 rounded border border-red-300 bg-red-50 p-3 text-red-700">
+          {error}
+        </div>
+      )}
+      {!loading && !error && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {products.map(p => (
+            <div key={p.id} className="rounded bg-white p-4 shadow">
+              <h3 className="font-bold">{p.name}</h3>
+              <p className="text-sm text-gray-600">{p.description}</p>
+              <div className="mt-2 flex items-center justify-between">
+                <div className="text-lg font-semibold">${p.price}</div>
+                <Link to={`/products/${p.id}`} className="text-sm text-blue-600">
+                  View
+                </Link>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- normalize the API base URL and strip leading slashes so product requests hit the backend API
- add robust product loading state handling and display a friendly error when the payload is unexpected
- surface login and registration call-to-action buttons on the home hero section and ensure the routed home page renders them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c8757e948333b0e0624af59938e0