### PR TITLE
Hide back button on home page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
-import { Routes, Route, Outlet } from 'react-router-dom'
+import { Routes, Route, Outlet, useLocation } from 'react-router-dom'
 import Navbar from './components/Navbar'
+import BackButton from './components/BackButton'
 import Home from './pages/Home'
 import Products from './pages/Products'
 import ProductDetail from './pages/ProductDetail'
@@ -9,11 +10,17 @@ import Login from './pages/Login'
 import Register from './pages/Register'
 
 function AppLayout(){
+  const location = useLocation()
+  const isHome = location.pathname === '/'
+
   return (
     <div className="min-h-screen bg-slate-100">
       <Navbar />
-      <main className="container mx-auto px-4 py-8">
-        <Outlet />
+      <main className="container mx-auto px-4 py-8 space-y-6">
+        {!isHome && <BackButton />}
+        <div>
+          <Outlet />
+        </div>
       </main>
     </div>
   )
@@ -28,9 +35,9 @@ export default function App(){
         <Route path="/products/:id" element={<ProductDetail />} />
         <Route path="/cart" element={<Cart />} />
         <Route path="/checkout" element={<Checkout />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
       </Route>
-      <Route path="/login" element={<Login />} />
-      <Route path="/register" element={<Register />} />
     </Routes>
   )
 }

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom'
+
+export default function BackButton(){
+  const navigate = useNavigate()
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(-1)}
+      className="group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:from-sky-600 hover:to-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+    >
+      <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/20 transition group-hover:bg-white/30">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="1.5"
+          stroke="currentColor"
+          className="h-4 w-4"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M10.5 19.5 3 12l7.5-7.5M3 12h18"
+          />
+        </svg>
+      </span>
+      <span>Volver</span>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- update the shared layout to detect the current route
- avoid rendering the BackButton component on the home page so only other views show it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4cbe7a0dc8333bfdc204ae0db9b5c