### PR TITLE
Add product imagery to product listing and detail views

### DIFF
--- a/src/pages/ProductDetail.jsx
+++ b/src/pages/ProductDetail.jsx
@@ -26,8 +26,17 @@ export default function ProductDetail(){
 
   if (!product) return <div>Loading...</div>
 
+  const imageUrl = product?.imageUrl ?? product?.image_url
+
   return (
-    <div className="bg-white p-6 rounded shadow">
+    <div className="space-y-4 rounded bg-white p-6 shadow">
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt={product.name}
+          className="mx-auto w-full max-w-md rounded object-cover"
+        />
+      )}
       <h2 className="text-2xl font-bold">{product.name}</h2>
       <p className="mt-2 text-gray-700">{product.description}</p>
       <div className="mt-4 flex items-center justify-between">

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -45,18 +45,29 @@ export default function Products(){
       )}
       {!loading && !error && (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {products.map(p => (
-            <div key={p.id} className="rounded bg-white p-4 shadow">
-              <h3 className="font-bold">{p.name}</h3>
-              <p className="text-sm text-gray-600">{p.description}</p>
-              <div className="mt-2 flex items-center justify-between">
-                <div className="text-lg font-semibold">${p.price}</div>
-                <Link to={`/products/${p.id}`} className="text-sm text-blue-600">
-                  View
-                </Link>
+          {products.map(p => {
+            const imageUrl = p.imageUrl ?? p.image_url
+
+            return (
+              <div key={p.id} className="space-y-2 overflow-hidden rounded bg-white p-4 shadow">
+                {imageUrl && (
+                  <img
+                    src={imageUrl}
+                    alt={p.name}
+                    className="h-40 w-full rounded object-cover"
+                  />
+                )}
+                <h3 className="font-bold">{p.name}</h3>
+                <p className="text-sm text-gray-600">{p.description}</p>
+                <div className="mt-2 flex items-center justify-between">
+                  <div className="text-lg font-semibold">${p.price}</div>
+                  <Link to={`/products/${p.id}`} className="text-sm text-blue-600">
+                    View
+                  </Link>
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- render product images in the product grid when URLs are provided and adjust card spacing to fit the media
- add the featured product image to the product detail page with responsive styling
- guard the new image elements so the UI remains clean when no image URL is available

## Testing
- npm run dev -- --host

------
https://chatgpt.com/codex/tasks/task_e_68d6084aa3a88333b692a568180cf72a