### PR TITLE
Show welcome popup after registration

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,48 @@
-import { Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
 export default function Home(){
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [welcomeMessage, setWelcomeMessage] = useState('')
+  const [showPopup, setShowPopup] = useState(false)
+
+  useEffect(() => {
+    if (location.state?.welcomeMessage) {
+      setWelcomeMessage(location.state.welcomeMessage)
+      setShowPopup(true)
+      navigate(location.pathname, { replace: true, state: {} })
+    }
+  }, [location, navigate])
+
+  useEffect(() => {
+    if (!showPopup) return
+
+    const timeout = setTimeout(() => setShowPopup(false), 5000)
+
+    return () => clearTimeout(timeout)
+  }, [showPopup])
+
   return (
     <div>
+      {showPopup && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="relative w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+            <button
+              type="button"
+              aria-label="Cerrar mensaje de bienvenida"
+              onClick={() => setShowPopup(false)}
+              className="absolute right-3 top-3 rounded-full p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700"
+            >
+              <span className="sr-only">Cerrar</span>
+              ×
+            </button>
+            <h2 className="text-2xl font-semibold text-gray-800">¡Registro exitoso!</h2>
+            <p className="mt-3 text-gray-600">{welcomeMessage}</p>
+          </div>
+        </div>
+      )}
+
       <header className="mb-6 rounded bg-white p-6 shadow">
         <h1 className="text-3xl font-bold">Welcome to the store</h1>
         <p className="mt-2 text-gray-600">Shop the best deals</p>

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from 'react'
+import { useState, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { AuthContext } from '../context/AuthContext'
 
@@ -10,46 +10,19 @@ export default function Register(){
   const navigate = useNavigate()
   const [status, setStatus] = useState({ type: null, message: '' })
 
-  useEffect(() => {
-    if (status.type === 'success') {
-      const timeout = setTimeout(() => {
-        navigate('/login')
-      }, 2000)
-
-      return () => clearTimeout(timeout)
-    }
-  }, [status.type, navigate])
-
   const handle = async (e) => {
     e.preventDefault()
     setStatus({ type: null, message: '' })
     try {
       await register(email, password, fullName)
+      const welcomeMessage = `¡Bienvenido, ${fullName}!`
       setFullName('')
       setEmail('')
       setPassword('')
-      setStatus({ type: 'success', message: 'Registro exitoso. Redirigiendo al inicio de sesión...' })
+      navigate('/', { state: { welcomeMessage } })
     } catch (err) {
       setStatus({ type: 'error', message: 'No se pudo completar el registro. Intenta nuevamente.' })
     }
-  }
-
-  if (status.type === 'success') {
-    return (
-      <div className="flex justify-center mt-20">
-        <div className="flex flex-col gap-4 p-6 border rounded w-96 bg-white text-center">
-          <h2 className="text-2xl font-semibold text-green-700">¡Registro exitoso!</h2>
-          <p>{status.message}</p>
-          <button
-            type="button"
-            onClick={() => navigate('/login')}
-            className="bg-green-600 text-white px-4 py-2 rounded"
-          >
-            Ir al inicio de sesión
-          </button>
-        </div>
-      </div>
-    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- send a welcome message in the navigation state after successful registration
- display a dismissible welcome popup on the home page using the navigation state
- automatically clear the route state and hide the popup after a short delay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73611ab8c833385f42c9fe7fc611f