### PR TITLE
Show welcome popup after registration and hide auth links when logged in

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,24 +1,54 @@
-import { Link } from 'react-router-dom'
+import { useContext, useEffect, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { AuthContext } from '../context/AuthContext'
+
 export default function Home(){
+  const { user } = useContext(AuthContext)
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { state, pathname } = location
+  const [welcomeMessage, setWelcomeMessage] = useState('')
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (state?.welcomeMessage) {
+      setWelcomeMessage(state.welcomeMessage)
+      setIsVisible(true)
+      navigate(pathname, { replace: true, state: {} })
+    }
+  }, [state, pathname, navigate])
+
+  useEffect(() => {
+    if (!isVisible) return
+
+    const timeout = setTimeout(() => {
+      setIsVisible(false)
+    }, 5000)
+
+    return () => clearTimeout(timeout)
+  }, [isVisible])
+
   return (
     <div>
       <header className="mb-6 rounded bg-white p-6 shadow">
         <h1 className="text-3xl font-bold">Welcome to the store</h1>
         <p className="mt-2 text-gray-600">Shop the best deals</p>
-        <div className="mt-4 flex flex-wrap gap-3">
-          <Link
-            to="/login"
-            className="rounded bg-blue-600 px-5 py-2 text-white shadow hover:bg-blue-700"
-          >
-            Iniciar sesión
-          </Link>
-          <Link
-            to="/register"
-            className="rounded border border-blue-600 px-5 py-2 text-blue-600 hover:bg-blue-50"
-          >
-            Crear cuenta
-          </Link>
-        </div>
+        {!user && (
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link
+              to="/login"
+              className="rounded bg-blue-600 px-5 py-2 text-white shadow hover:bg-blue-700"
+            >
+              Iniciar sesión
+            </Link>
+            <Link
+              to="/register"
+              className="rounded border border-blue-600 px-5 py-2 text-blue-600 hover:bg-blue-50"
+            >
+              Crear cuenta
+            </Link>
+          </div>
+        )}
       </header>
 
       <section>
@@ -27,6 +57,22 @@ export default function Home(){
           <Link to="/products" className="p-4 bg-white rounded shadow hover:shadow-md">Browse products →</Link>
         </div>
       </section>
+
+      {isVisible && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="w-80 rounded-lg bg-white p-6 text-center shadow-lg">
+            <h3 className="text-xl font-semibold text-green-700">{welcomeMessage}</h3>
+            <p className="mt-2 text-gray-600">¡Gracias por registrarte! Disfruta de tu experiencia de compra.</p>
+            <button
+              type="button"
+              onClick={() => setIsVisible(false)}
+              className="mt-4 rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from 'react'
+import { useState, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { AuthContext } from '../context/AuthContext'
 
@@ -6,50 +6,24 @@ export default function Register(){
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [fullName, setFullName] = useState('')
+  const [error, setError] = useState('')
   const { register } = useContext(AuthContext)
   const navigate = useNavigate()
-  const [status, setStatus] = useState({ type: null, message: '' })
-
-  useEffect(() => {
-    if (status.type === 'success') {
-      const timeout = setTimeout(() => {
-        navigate('/login')
-      }, 2000)
-
-      return () => clearTimeout(timeout)
-    }
-  }, [status.type, navigate])
 
   const handle = async (e) => {
     e.preventDefault()
-    setStatus({ type: null, message: '' })
+    setError('')
+
     try {
+      const trimmedName = fullName.trim()
       await register(email, password, fullName)
       setFullName('')
       setEmail('')
       setPassword('')
-      setStatus({ type: 'success', message: 'Registro exitoso. Redirigiendo al inicio de sesión...' })
+      navigate('/', { state: { welcomeMessage: trimmedName ? `¡Bienvenido, ${trimmedName}!` : '¡Registro exitoso!' } })
     } catch (err) {
-      setStatus({ type: 'error', message: 'No se pudo completar el registro. Intenta nuevamente.' })
+      setError('No se pudo completar el registro. Intenta nuevamente.')
     }
-  }
-
-  if (status.type === 'success') {
-    return (
-      <div className="flex justify-center mt-20">
-        <div className="flex flex-col gap-4 p-6 border rounded w-96 bg-white text-center">
-          <h2 className="text-2xl font-semibold text-green-700">¡Registro exitoso!</h2>
-          <p>{status.message}</p>
-          <button
-            type="button"
-            onClick={() => navigate('/login')}
-            className="bg-green-600 text-white px-4 py-2 rounded"
-          >
-            Ir al inicio de sesión
-          </button>
-        </div>
-      </div>
-    )
   }
 
   return (
@@ -58,8 +32,8 @@ export default function Register(){
         <input className="p-2 border rounded" value={fullName} onChange={e=>setFullName(e.target.value)} placeholder="Full name" />
         <input className="p-2 border rounded" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email" required />
         <input className="p-2 border rounded" type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="Password" required />
-        {status.type === 'error' && (
-          <p className="text-sm text-red-600">{status.message}</p>
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
         )}
         <button className="bg-green-600 text-white px-4 py-2 rounded">Register</button>
       </form>


### PR DESCRIPTION
## Summary
- redirect new accounts to the home page with a welcome message stored in navigation state
- show a modal-style welcome pop-up on the home page and hide the auth actions once a user is authenticated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d735af52148333b724a77949a396ce