### PR TITLE
Fix Home popup visibility state handling

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 export default function Home(){
   const navigate = useNavigate()
   const location = useLocation()
-  const popupMessage = useMemo(() => location.state?.popupMessage ?? '', [location.state])
-  const [showPopup, setShowPopup] = useState(Boolean(popupMessage))
+  const popupMessage = location.state?.popupMessage ?? ''
+  const popupDuration = location.state?.popupDuration ?? 2000
+  const [showPopup, setShowPopup] = useState(false)
 
   useEffect(() => {
     if (!popupMessage) {
@@ -18,10 +19,10 @@ export default function Home(){
     const timeout = setTimeout(() => {
       setShowPopup(false)
       navigate('.', { replace: true, state: {} })
-    }, location.state?.popupDuration ?? 2000)
+    }, popupDuration)
 
     return () => clearTimeout(timeout)
-  }, [popupMessage, navigate, location.state])
+  }, [popupMessage, popupDuration, navigate])
 
   const handleClose = () => {
     setShowPopup(false)

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,62 @@
-import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
 export default function Home(){
+  const navigate = useNavigate()
+  const location = useLocation()
+  const popupMessage = useMemo(() => location.state?.popupMessage ?? '', [location.state])
+  const [showPopup, setShowPopup] = useState(Boolean(popupMessage))
+
+  useEffect(() => {
+    if (!popupMessage) {
+      setShowPopup(false)
+      return
+    }
+
+    setShowPopup(true)
+
+    const timeout = setTimeout(() => {
+      setShowPopup(false)
+      navigate('.', { replace: true, state: {} })
+    }, location.state?.popupDuration ?? 2000)
+
+    return () => clearTimeout(timeout)
+  }, [popupMessage, navigate, location.state])
+
+  const handleClose = () => {
+    setShowPopup(false)
+    navigate('.', { replace: true, state: {} })
+  }
+
   return (
     <div>
+      {showPopup && popupMessage && (
+        <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/40">
+          <div className="max-w-sm rounded-lg bg-white p-6 text-center shadow-lg">
+            <p className="mb-4 text-gray-800">{popupMessage}</p>
+            <div className="flex justify-center gap-3">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              >
+                Cerrar
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowPopup(false)
+                  navigate('/login')
+                }}
+                className="rounded border border-blue-600 px-4 py-2 text-blue-600 hover:bg-blue-50"
+              >
+                Ir al inicio de sesión
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <header className="mb-6 rounded bg-white p-6 shadow">
         <h1 className="text-3xl font-bold">Welcome to the store</h1>
         <p className="mt-2 text-gray-600">Shop the best deals</p>
@@ -23,8 +78,8 @@ export default function Home(){
 
       <section>
         <h2 className="text-xl font-semibold mb-4">Featured</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <Link to="/products" className="p-4 bg-white rounded shadow hover:shadow-md">Browse products →</Link>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Link to="/products" className="rounded bg-white p-4 shadow hover:shadow-md">Browse products →</Link>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- switch the home popup visibility tuple to `showPopup`/`setShowPopup` and reuse it across the modal logic
- preserve the existing popup message, navigation, and timeout behavior while ensuring the modal can close cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73b9952f08333a1ba20ff956a643a