### PR TITLE
Fix auth context defaults and navbar logout guard

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,9 +1,18 @@
 import { Link } from 'react-router-dom'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { AuthContext } from '../context/AuthContext'
 
 export default function Navbar(){
-  const { user, logout } = useContext(AuthContext)
+  const auth = useContext(AuthContext)
+  const { isAuthenticated, onLogout } = useMemo(() => {
+    const user = auth?.user ?? null
+    const logout = auth?.logout
+
+    return {
+      isAuthenticated: Boolean(user),
+      onLogout: typeof logout === 'function' ? logout : () => {},
+    }
+  }, [auth])
   return (
     <nav className="bg-white shadow">
       <div className="container flex items-center justify-between py-4">
@@ -11,8 +20,8 @@ export default function Navbar(){
         <div className="flex items-center gap-4">
           <Link to="/products" className="hover:underline">Products</Link>
           <Link to="/cart" className="hover:underline">Cart</Link>
-          {user ? (
-            <button onClick={logout} className="px-3 py-1 bg-red-500 text-white rounded">Logout</button>
+          {isAuthenticated ? (
+            <button onClick={onLogout} className="px-3 py-1 bg-red-500 text-white rounded">Logout</button>
           ) : (
             <>
               <Link to="/login" className="px-3 py-1 bg-blue-500 text-white rounded">Login</Link>


### PR DESCRIPTION
## Summary
- add safe defaults for the auth context and memoize the provided value
- guard navbar authentication state checks to avoid undefined user references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d74bf6b6a8833386660aa363406ad1