### PR TITLE
Fix cart item display

### DIFF
--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -2,6 +2,78 @@ import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import api from '../api/api'
 
+const normalizeCartItems = list => {
+  if (!Array.isArray(list)) return []
+
+  return list.map((raw, index) => {
+    const product = raw?.product || raw?.Product || raw?.productDto || raw?.item || {}
+
+    const productName =
+      raw?.productName ||
+      product?.name ||
+      product?.title ||
+      product?.productName ||
+      product?.nombre ||
+      'Producto'
+
+    const quantityRaw = raw?.quantity ?? raw?.qty ?? raw?.amount ?? raw?.units
+    const quantity = Number.parseInt(quantityRaw, 10)
+    const safeQuantity = Number.isFinite(quantity) && quantity > 0 ? quantity : 1
+
+    const priceSource =
+      raw?.price ??
+      raw?.unitPrice ??
+      raw?.unit_price ??
+      raw?.productPrice ??
+      product?.price ??
+      product?.unitPrice ??
+      product?.unit_price
+    const unitPrice = Number(priceSource)
+    const safeUnitPrice = Number.isFinite(unitPrice) && unitPrice >= 0 ? unitPrice : 0
+
+    const totalSource = raw?.total ?? raw?.totalPrice ?? raw?.total_price
+    const totalPrice = Number(totalSource)
+    const computedTotal = Number.isFinite(totalPrice) && totalPrice >= 0 ? totalPrice : safeUnitPrice * safeQuantity
+
+    const imageUrl =
+      raw?.imageUrl ||
+      raw?.image_url ||
+      product?.imageUrl ||
+      product?.image_url ||
+      product?.image ||
+      product?.photoUrl ||
+      product?.photo_url ||
+      ''
+
+    const id =
+      raw?.id ??
+      raw?.cartItemId ??
+      raw?.cart_item_id ??
+      raw?.productId ??
+      product?.id ??
+      `${index}`
+
+    return {
+      id,
+      productName,
+      quantity: safeQuantity,
+      unitPrice: safeUnitPrice,
+      totalPrice: computedTotal,
+      imageUrl,
+    }
+  })
+}
+
+const formatCurrency = value => {
+  if (!Number.isFinite(value)) return '—'
+  return value.toLocaleString('es-PE', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
 export default function Cart(){
   const [items, setItems] = useState([])
   const navigate = useNavigate()
@@ -12,11 +84,11 @@ export default function Cart(){
       .then(res => {
         const payload = res?.data
         if (Array.isArray(payload)) {
-          setItems(payload)
+          setItems(normalizeCartItems(payload))
         } else if (payload && Array.isArray(payload.data)) {
-          setItems(payload.data)
+          setItems(normalizeCartItems(payload.data))
         } else if (payload && Array.isArray(payload.items)) {
-          setItems(payload.items)
+          setItems(normalizeCartItems(payload.items))
         } else {
           console.error('Formato inesperado del carrito', payload)
           setItems([])
@@ -45,12 +117,26 @@ export default function Cart(){
       <h2 className="text-2xl font-semibold mb-4">Your Cart</h2>
       <div className="space-y-4">
         {items.map(it => (
-          <div key={it.id} className="bg-white p-4 rounded shadow flex justify-between">
-            <div>
-              <div className="font-semibold">{it.productName}</div>
-              <div className="text-sm text-gray-600">Qty: {it.quantity}</div>
+          <div key={it.id} className="bg-white p-4 rounded shadow flex items-center justify-between gap-4">
+            <div className="flex items-center gap-4">
+              {it.imageUrl ? (
+                <img
+                  src={it.imageUrl}
+                  alt={it.productName}
+                  className="h-16 w-16 rounded object-cover"
+                />
+              ) : (
+                <div className="flex h-16 w-16 items-center justify-center rounded bg-gray-100 text-sm text-gray-400">
+                  Sin imagen
+                </div>
+              )}
+              <div>
+                <div className="font-semibold">{it.productName}</div>
+                <div className="text-sm text-gray-600">Cantidad: {it.quantity}</div>
+                <div className="text-sm text-gray-500">Precio unitario: {formatCurrency(it.unitPrice)}</div>
+              </div>
             </div>
-            <div className="text-lg font-semibold">${it.price * it.quantity}</div>
+            <div className="text-lg font-semibold">{formatCurrency(it.totalPrice)}</div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- normalize cart responses so product name, image, and price always render
- add currency formatting and image fallback in the cart UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d74cb3f0388333bf75c25524f9061b