### PR TITLE
Fix cart item delete endpoint

### DIFF
--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -169,7 +169,7 @@ export default function Cart(){
     setRemovingId(cartItemId)
 
     try {
-      await api.delete(`/cart/item/${cartItemId}`)
+      await api.delete(`/cart/items/${cartItemId}`)
       setItems(prev => prev.filter(it => it.id !== cartItemId && it.productId !== productId))
       setQuantityDrafts(prev => {
         const next = { ...prev }


### PR DESCRIPTION
## Summary
- update the cart removal request to call the pluralized items endpoint so it matches the backend API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d76cc7448c8333853503173ed59a2c