### PR TITLE
Display user emails in invoices and improve product names

### DIFF
--- a/src/pages/InvoiceDetail.jsx
+++ b/src/pages/InvoiceDetail.jsx
@@ -17,9 +17,15 @@ const normalizeInvoiceItems = list => {
     const productName =
       rawItem?.productName ||
       rawItem?.product_name ||
+      rawItem?.nombreProducto ||
+      rawItem?.productTitle ||
+      rawItem?.product_title ||
       product?.name ||
       product?.title ||
       product?.productName ||
+      product?.product_name ||
+      product?.nameProduct ||
+      product?.nombreProducto ||
       product?.nombre ||
       `Producto ${rawItem?.productId ?? rawItem?.product_id ?? index + 1}`;
 

--- a/src/pages/Invoices.jsx
+++ b/src/pages/Invoices.jsx
@@ -9,6 +9,45 @@ export default function Invoices() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
+  const resolveUserEmail = invoice => {
+    if (!invoice) return "—";
+
+    const userLike =
+      invoice.user ||
+      invoice.User ||
+      invoice.customer ||
+      invoice.Customer ||
+      invoice.usuario ||
+      invoice.Usuario ||
+      {};
+
+    const emailCandidate =
+      invoice.userEmail ??
+      invoice.user_email ??
+      invoice.email ??
+      invoice.emailUsuario ??
+      invoice.usuarioEmail ??
+      userLike.email ??
+      userLike.mail ??
+      userLike.emailAddress ??
+      userLike.email_address ??
+      userLike.correo ??
+      userLike.correoElectronico ??
+      userLike.correo_electronico ??
+      null;
+
+    if (emailCandidate) return emailCandidate;
+
+    const identifier =
+      invoice.userId ??
+      invoice.user_id ??
+      userLike.id ??
+      userLike.userId ??
+      null;
+
+    return identifier ? `Usuario ${identifier}` : "Usuario sin email";
+  };
+
   useEffect(() => {
     const fetchInvoices = async () => {
       try {
@@ -49,10 +88,10 @@ export default function Invoices() {
             </tr>
           </thead>
           <tbody>
-            {invoices.map((inv, i) => (
+            {invoices.map(inv => (
               <tr key={inv.id} className="border-b">
                 <td className="px-4 py-2">{inv.invoiceNumber}</td>
-                <td className="px-4 py-2">{inv.userId}</td>
+                <td className="px-4 py-2">{resolveUserEmail(inv)}</td>
                 <td className="px-4 py-2">${inv.total}</td>
                 <td className="px-4 py-2">{inv.status}</td>
                 <td className="px-4 py-2">


### PR DESCRIPTION
## Summary
- resolve user emails on the invoice listing from multiple possible API response shapes
- broaden invoice item normalization so product names appear reliably in the detail table

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d76d34f15c8333bee356311ad5147d