### PR TITLE
Redirect checkout invoice action to list

### DIFF
--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -147,7 +147,7 @@ export default function Checkout() {
         subtotal,
         total,
       };
-      const res = await axios.post(
+      await axios.post(
         `${import.meta.env.VITE_API_URL}/api/Invoices`,
         payload,
         {
@@ -155,7 +155,7 @@ export default function Checkout() {
         }
       );
       alert("Factura generada con éxito ✅");
-      navigate(`/invoices/${res.data.id}`);
+      navigate("/invoices");
     } catch (err) {
       alert("Error al generar la factura ❌");
     }


### PR DESCRIPTION
## Summary
- adjust checkout invoice creation flow to stop using the created invoice id
- redirect users to the invoices list after generating an invoice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7740773388333846264f4c947319f